### PR TITLE
add-tomcat-native-support Add tomcat native support

### DIFF
--- a/8/phusion/Dockerfile
+++ b/8/phusion/Dockerfile
@@ -2,13 +2,14 @@ FROM stakater/java:oracle-8
 MAINTAINER Hamza <hamza@aurorasolutions.io>
 
 RUN apt-get update && \
-    apt-get install -yq --no-install-recommends wget pwgen ca-certificates && \
+    apt-get install -yq --no-install-recommends wget pwgen ca-certificates libtcnative-1 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 ENV TOMCAT_MAJOR_VERSION 8
 ENV TOMCAT_MINOR_VERSION 8.5.11
 ENV CATALINA_HOME /tomcat
+ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:/usr/lib/x86_64-linux-gnu/
 
 # INSTALL TOMCAT
 RUN wget -q https://archive.apache.org/dist/tomcat/tomcat-${TOMCAT_MAJOR_VERSION}/v${TOMCAT_MINOR_VERSION}/bin/apache-tomcat-${TOMCAT_MINOR_VERSION}.tar.gz && \


### PR DESCRIPTION
Added support for tomcat native library. The APR based Apache Tomcat Native library allows optimal performance in production environments.